### PR TITLE
MacOS CI, Valgrind cleanness, output fix

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,6 +14,16 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         compiler: [ clang, gcc ]
         type: [ Debug, Release ]
+        exclude:
+          - os: macos-latest
+            compiler: gcc
+        include:
+          - os: macos-latest
+            compiler: gcc-11
+            type: Debug
+          - os: macos-latest
+            compiler: gcc-11
+            type: Release
     steps:
       - name: Checkpout repository
         uses: actions/checkout@v2

--- a/src/distributed/mpi.c
+++ b/src/distributed/mpi.c
@@ -197,6 +197,9 @@ void mpi_remote_msg_handle(void)
 				continue;
 			}
 			msg = msg_allocator_alloc(0);
+			// make sure the deterministic tie-breaking doesn't read uninitialized data
+			msg->m_type = 0;
+			msg->pl_size = 0;
 			MPI_Mrecv(msg, size, MPI_BYTE, &mpi_msg, MPI_STATUS_IGNORE);
 
 			gvt_remote_anti_msg_receive(msg);

--- a/src/init.c
+++ b/src/init.c
@@ -27,6 +27,18 @@ static bool configuration_done = false;
 struct simulation_configuration global_config = {0};
 
 /**
+ * @brief Prints a fancy ROOT-Sim logo
+ */
+static void print_logo(void)
+{
+	fprintf(stderr, "\x1b[94m   __ \x1b[90m __   _______   \x1b[94m  _ \x1b[90m       \n");
+	fprintf(stderr, "\x1b[94m  /__)\x1b[90m/  ) /  ) /  __ \x1b[94m ( `\x1b[90m . ___ \n");
+	fprintf(stderr, "\x1b[94m / \\ \x1b[90m(__/ (__/ (      \x1b[94m._)\x1b[90m / / / )\n");
+	fprintf(stderr, "\x1b[0m\n");
+}
+
+
+/**
  * @brief Pretty prints ROOT-Sim current configuration
  */
 static void print_config(void)
@@ -120,15 +132,19 @@ int RootsimRun(void)
 	if(!configuration_done)
 		return -1;
 
-	if(global_config.log_level > LOG_SILENT)
+	if(!global_config.serial)
+		mpi_global_init(NULL, NULL);
+
+	if(global_config.log_level < LOG_SILENT) {
+		print_logo();
 		print_config();
+	}
 
 	stats_global_time_start();
 
 	if(global_config.serial) {
 		ret = serial_simulation();
 	} else {
-		mpi_global_init(NULL, NULL);
 		ret = parallel_simulation();
 		mpi_global_fini();
 	}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -63,27 +63,11 @@ void vlogger(unsigned level, char *file, unsigned line, const char *fmt, ...)
 }
 
 /**
- * @brief Prints a fancy ROOT-Sim logo
- */
-static void print_logo(void)
-{
-	fprintf(stderr, "\x1b[94m   __ \x1b[90m __   _______   \x1b[94m  _ \x1b[90m       \n");
-	fprintf(stderr, "\x1b[94m  /__)\x1b[90m/  ) /  ) /  __ \x1b[94m ( `\x1b[90m . ___ \n");
-	fprintf(stderr, "\x1b[94m / \\ \x1b[90m(__/ (__/ (      \x1b[94m._)\x1b[90m / / / )\n");
-	fprintf(stderr, "\x1b[0m\n");
-}
-
-/**
  * @brief Initialize the logging subsystem
  *
  * @param file The FILE to write logging information to. If set to NULL, it is defaulted to stdout.
  */
 void log_init(FILE *file)
 {
-	logfile = file;
-	if(logfile == NULL)
-		logfile = stdout;
-
-	if(global_config.log_level != LOG_SILENT)
-		print_logo();
+	logfile = logfile == NULL ? stdout : file;
 }

--- a/test/framework/thread.c
+++ b/test/framework/thread.c
@@ -78,12 +78,11 @@ thrd_ret_t test_worker(void *args)
 
 void spawn_worker_pool(unsigned n_th)
 {
-	test_unit.n_th = n_th;
-	rid = (rid_t)-1;
-
 	if(n_th == 0)
 		return;
 
+	test_unit.n_th = n_th;
+	rid = (rid_t)-1;
 	work = sema_init(0);
 	ready = sema_init(0);
 	all_done = sema_init(0);


### PR DESCRIPTION
This PR brings this three improvements:
- the gcc/MacOS CI actually uses gcc
- we are 100% Valgrind clean, even in distributed (when using MPICH, OpenMPI is a mess)
- the configuration is now properly printed when the logging level is not LOG_SILENT