### PR TITLE
Fixed a memory leak in the test lp mock framework

### DIFF
--- a/test/framework/lp.c
+++ b/test/framework/lp.c
@@ -8,14 +8,14 @@
 * SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
 * SPDX-License-Identifier: GPL-3.0-only
 */
-#include <stdbool.h>
-#include <lp/lp.h>
 #include <datatypes/list.h>
+#include <lp/lp.h>
 
-static bool initialiazed = false;
+#include <stdbool.h>
 
 struct lp_mock_t {
-	struct lp_ctx *ctx;
+	struct lp_ctx lp;
+	struct lib_ctx lp_lib;
 	struct lp_mock_t *next;
 	struct lp_mock_t *prev;
 };
@@ -27,31 +27,31 @@ static void lp_exit(void)
 	struct lp_mock_t *mock;
 	while ((mock = list_head(lp_mocks)) != NULL) {
 		list_delete_by_content(lp_mocks, mock);
-		free(mock->ctx);
 		free(mock);
 	}
 }
 
 struct lp_ctx *mock_lp()
 {
-	struct lp_ctx *lp = malloc(sizeof(struct lp_ctx));
-	memset(lp, 0, sizeof(struct lp_ctx));
-	struct lib_ctx *ctx = malloc(sizeof(struct lib_ctx));
-	memset(ctx, 0, sizeof(struct lib_ctx));
+	struct lp_mock_t *mock = malloc(sizeof(*mock));
+	memset(mock, 0, sizeof(*mock));
+
+	struct lp_ctx *lp = &mock->lp;
+	struct lib_ctx *ctx = &mock->lp_lib;
+
 	lp->lib_ctx = ctx;
 	ctx->rng_s[0] = 7319936632422683443ULL;
 	ctx->rng_s[1] = 2268344373199366324ULL;
 	ctx->rng_s[2] = 3443862242366399137ULL;
 	ctx->rng_s[3] = 2366399137344386224ULL;
 
-	if(!initialiazed) {
+	static bool initialized = false;
+	if(!initialized) {
 		lp_mocks = new_list(struct lp_mock_t);
 		atexit(lp_exit);
-		initialiazed = true;
+		initialized = true;
 	}
 
-	struct lp_mock_t *mock = malloc(sizeof(struct lp_mock_t));
-	mock->ctx = lp;
 	list_insert_head(lp_mocks, mock);
 
 	return lp;


### PR DESCRIPTION
This PR fixes a memory leak in the lp test mocking routine