### PR TITLE
Fix the autodeployment of the documentation

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Checkpout repository
         uses: actions/checkout@v3
       - name: Initialize Environment
-        uses: ROOT-Sim/ci-actions/init@master
+        uses: ROOT-Sim/ci-actions/init@v1.2
       - name: Build & Test
-        uses: ROOT-Sim/ci-actions/cmake@master
+        uses: ROOT-Sim/ci-actions/cmake@v1.2
         with:
           build-dir: ${{ runner.workspace }}/build
           cc: ${{ matrix.compiler }}

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -10,9 +10,9 @@ jobs:
       - name: Fetch ROOT-Sim repository
         uses: actions/checkout@v3
       - name: Initialize Environment
-        uses: ROOT-Sim/ci-actions/init@master
+        uses: ROOT-Sim/ci-actions/init@v1.2
       - name: Build & Test
-        uses: ROOT-Sim/ci-actions/cmake@master
+        uses: ROOT-Sim/ci-actions/cmake@v1.2
         with:
           build-dir: ${{ runner.workspace }}/build
           cc: gcc

--- a/.github/workflows/doc_coverage.yml
+++ b/.github/workflows/doc_coverage.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v1
       - name: Initialize Environment
-        uses: ROOT-Sim/ci-actions/init@master
+        uses: ROOT-Sim/ci-actions/init@v1.2
       - name: Generate Documentation
-        uses: ROOT-Sim/ci-actions/docs@master
+        uses: ROOT-Sim/ci-actions/docs@v1.2
       - name: Documentation Coverage
-        uses: ROOT-Sim/ci-actions/docs-coverage@master
+        uses: ROOT-Sim/ci-actions/docs-coverage@v1.2
         with:
           build-path: docs
       - name: Comment PR

--- a/.github/workflows/reuse_check.yml
+++ b/.github/workflows/reuse_check.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkpout repository
         uses: actions/checkout@v3
       - name: REUSE check
-        uses: ROOT-Sim/ci-actions/reuse-check@master
+        uses: ROOT-Sim/ci-actions/reuse-check@v1.2

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,14 +14,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v1
       - name: Initialize Environment
-        uses: ROOT-Sim/ci-actions/init@master
+        uses: ROOT-Sim/ci-actions/init@v1.2
       - name: Generate Documentation
-        uses: ROOT-Sim/ci-actions/docs@master
+        uses: ROOT-Sim/ci-actions/docs@v1.2
       - name: Documentation Coverage
-        uses: ROOT-Sim/ci-actions/docs-coverage@master
+        uses: ROOT-Sim/ci-actions/docs-coverage@v1.2
         with:
           build-path: docs
       - name: Website Deployment
-        uses: ROOT-Sim/ci-actions/website-deploy@master
+        uses: ROOT-Sim/ci-actions/website-deploy@v1.2
         with:
           build-path: docs

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -2,9 +2,6 @@ name: Documentation Deployment
 
 on:
   push:
-    branches:
-      - master
-      - develop
 
 jobs:
   update-website:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -2,6 +2,9 @@ name: Documentation Deployment
 
 on:
   push:
+    branches:
+      - master
+      - develop
 
 jobs:
   update-website:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,3 +20,5 @@ jobs:
           build-path: docs
       - name: Website Deployment
         uses: ROOT-Sim/ci-actions/website-deploy@master
+        with:
+          build-path: docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.10)
 project("ROOT-Sim core" LANGUAGES C DESCRIPTION "A General-Purpose Multi-threaded Parallel/Distributed Simulation Library")
 
-set(PROJECT_VERSION v3.0.0-alpha.5)
+set(PROJECT_VERSION 3.0.0-alpha.5)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.10)
 project("ROOT-Sim core" LANGUAGES C DESCRIPTION "A General-Purpose Multi-threaded Parallel/Distributed Simulation Library")
 
-set(PROJECT_VERSION 3.0.0-alpha.4) # todo: use cmake project VERSION argument when we are out of the alpha
+set(PROJECT_VERSION v3.0.0-alpha.5)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Research Group*
 
 [![Build Status](https://github.com/ROOT-Sim/core/workflows/ROOT-Sim%20core%20CI/badge.svg)](https://github.com/ROOT-Sim/core/actions)
-[![codecov.io](https://codecov.io/gh/ROOT-Sim/branch/master/graphs/badge.svg)](https://codecov.io/gh/ROOT-Sim/core)
+[![codecov](https://codecov.io/gh/ROOT-Sim/core/branch/master/graph/badge.svg)](https://codecov.io/gh/ROOT-Sim/core)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/7519f016f3d942b9b12c6ed03ae4ecf8)](https://www.codacy.com/gh/ROOT-Sim/core/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ROOT-Sim/core&amp;utm_campaign=Badge_Grade)
 [![doc coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Froot-sim.github.io%2Fcore%2Fdocs%2Fmaster.json)](https://root-sim.github.io/core/docs/)
 [![GitHub issues](https://img.shields.io/github/issues/ROOT-Sim/core)](https://github.com/ROOT-Sim/core/issues)

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
-import re
-from subprocess import check_output
-import sys
 import os
+import re
+import sys
+from subprocess import check_output
 
 describe_str = check_output(['git', 'describe']).decode()
 branch_name = check_output(['git', 'branch', '--show-current']).decode().strip()
 
 # Split version in major, minor, hotfix, and tag
 version = describe_str.split("-", 1)[0]
-version = version[1:]
+version = version[1:]  # This is to remove the 'v' at the beginning of the previous tag name
 tag = "-" + describe_str.split("-", 1)[1].split("-", 1)[0]
 major, minor, hotfix = map(int, version.split(".", 3))
 
@@ -24,7 +24,7 @@ if tag.startswith("-alpha") or tag.startswith("-beta") or tag.startswith("-rc"):
 branch_type = branch_name.split("-", 1)[0]
 
 print(f"The current branch {branch_name} is of type {branch_type}")
-print(f"Current version is v{major}.{minor}.{hotfix}{tag}")
+print(f"Current version is {major}.{minor}.{hotfix}{tag}")
 
 if new_tag == "":
     # Check if we have to increment the major
@@ -41,7 +41,7 @@ if new_tag == "":
         print("Branch name doesn't tell the version should be bumped.")
         sys.exit(1)
 
-print(f"Applying new version number: v{major}.{minor}.{hotfix}{new_tag}. Continue? (y/n)")
+print(f"Applying new version number: {major}.{minor}.{hotfix}{new_tag}. Continue? (y/n)")
 if sys.stdin.read(1) != 'y':
     sys.exit(0)
 
@@ -52,8 +52,8 @@ with open(build_path, "r") as f:
     cmakelists = f.read()
 
 cmakelists, sub_cnt = re.subn(r"PROJECT_VERSION .*\)",
-                               f"PROJECT_VERSION v{major}.{minor}.{hotfix}{new_tag})",
-                               cmakelists, count=1)
+                              f"PROJECT_VERSION {major}.{minor}.{hotfix}{new_tag})",
+                              cmakelists, count=1)
 
 if sub_cnt != 1:
     print("Version pattern not found. The operation won't be completed.")
@@ -62,4 +62,4 @@ if sub_cnt != 1:
 with open(build_path, "w") as f:
     f.write(cmakelists)
 
-print(f"File modified successfully, version bumped to v{major}.{minor}.{hotfix}{new_tag}")
+print(f"File modified successfully, version bumped to {major}.{minor}.{hotfix}{new_tag}")

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -11,36 +11,37 @@ branch_name = check_output(['git', 'branch', '--show-current']).decode().strip()
 
 # Split version in major, minor, hotfix, and tag
 version = describe_str.split("-", 1)[0]
+version = version[1:]
 tag = "-" + describe_str.split("-", 1)[1].split("-", 1)[0]
 major, minor, hotfix = map(int, version.split(".", 3))
 
 new_tag = ""
 if tag.startswith("-alpha") or tag.startswith("-beta") or tag.startswith("-rc"):
     tag_version = int(tag.split(".")[1])
-    tag = tag.split(".")[0]
-    new_tag = f"{tag}.{tag_version + 1}"
+    new_tag = tag.split(".")[0]
+    new_tag = f"{new_tag}.{tag_version + 1}"
 
 branch_type = branch_name.split("-", 1)[0]
 
 print(f"The current branch {branch_name} is of type {branch_type}")
-print(f"Current version is {major}.{minor}.{hotfix}{new_tag}")
+print(f"Current version is v{major}.{minor}.{hotfix}{tag}")
 
-# Check if we have to increment the major
-if len(sys.argv) > 1 and sys.argv[1] ==  "major":
-    major += 1
-    minor = 0
-    hotfix = 0
-elif branch_type == "release":
-    if new_tag == "":
+if new_tag == "":
+    # Check if we have to increment the major
+    if len(sys.argv) > 1 and sys.argv[1] ==  "major":
+        major += 1
+        minor = 0
+        hotfix = 0
+    elif branch_type == "release":
         minor += 1
         hotfix = 0
-elif branch_type == "hotfix":
-    hotfix += 1
-else:
-    print("Branch name doesn't tell the version should be bumped.")
-    sys.exit(1)
+    elif branch_type == "hotfix":
+        hotfix += 1
+    else:
+        print("Branch name doesn't tell the version should be bumped.")
+        sys.exit(1)
 
-print(f"Applying new version number: {major}.{minor}.{hotfix}{new_tag}. Continue? (y/n)")
+print(f"Applying new version number: v{major}.{minor}.{hotfix}{new_tag}. Continue? (y/n)")
 if sys.stdin.read(1) != 'y':
     sys.exit(0)
 
@@ -51,7 +52,7 @@ with open(build_path, "r") as f:
     cmakelists = f.read()
 
 cmakelists, sub_cnt = re.subn(r"PROJECT_VERSION .*\)",
-                               f"PROJECT_VERSION {major}.{minor}.{hotfix}{new_tag})",
+                               f"PROJECT_VERSION v{major}.{minor}.{hotfix}{new_tag})",
                                cmakelists, count=1)
 
 if sub_cnt != 1:
@@ -61,4 +62,4 @@ if sub_cnt != 1:
 with open(build_path, "w") as f:
     f.write(cmakelists)
 
-print(f"File modified successfully, version bumped to {major}.{minor}.{hotfix}{new_tag}")
+print(f"File modified successfully, version bumped to v{major}.{minor}.{hotfix}{new_tag}")

--- a/test/tests/visibility/visibility_weak.c
+++ b/test/tests/visibility/visibility_weak.c
@@ -11,5 +11,5 @@
 
 int main(void)
 {
-	return strcmp(core_version, "v3.0.0-alpha.5");
+	return strcmp(core_version, "3.0.0-alpha.5");
 }

--- a/test/tests/visibility/visibility_weak.c
+++ b/test/tests/visibility/visibility_weak.c
@@ -11,5 +11,5 @@
 
 int main(void)
 {
-	return strcmp(core_version, "3.0.0-alpha.4");
+	return strcmp(core_version, "v3.0.0-alpha.5");
 }


### PR DESCRIPTION
This pull requests interacts with ROOT-Sim/ci-actions@3adadf1aed204ea7647a45163fb71b5617010d23 to deploy the documentation for the `master` and `develop` branches correctly to the GitHub Pages website.