### PR TITLE
Remove GCC specific __builtin_ia32_pause()

### DIFF
--- a/src/core/sync.h
+++ b/src/core/sync.h
@@ -14,6 +14,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#if defined(__x86_64__) || defined(__i386__)
+#include <immintrin.h>
+#endif
+
 /// The type of a spinlock, an efficient lock primitive in contended scenarios
 typedef atomic_flag spinlock_t;
 
@@ -28,7 +32,7 @@ typedef atomic_flag spinlock_t;
  * @brief Tells the compiler that we are inside a spin loop
  */
 #if defined(__x86_64__) || defined(__i386__)
-#define spin_pause() __builtin_ia32_pause()
+#define spin_pause() _mm_pause()
 #else
 #define spin_pause()
 #endif


### PR DESCRIPTION
This PR removes the GCC specific ```__builtin_ia32_pause()``` from the code base in favor of the ```_mm_pause()``` function included in the Intel specific ```immintrin.h``` header. This change allows to correctly build the core library with Intel compilers.