### PR TITLE
Fix of an inconsistent treatment of the member pl_size of struct lp_msg

### DIFF
--- a/src/mm/msg_allocator.h
+++ b/src/mm/msg_allocator.h
@@ -30,7 +30,6 @@ static inline struct lp_msg *msg_allocator_pack(lp_id_t receiver, simtime_t time
 	msg->dest = receiver;
 	msg->dest_t = timestamp;
 	msg->m_type = event_type;
-	msg->pl_size = payload_size;
 
 	if(likely(payload_size))
 		memcpy(msg->pl, payload, payload_size);


### PR DESCRIPTION
As indicated in the title, this PR fixes an inconsistent treatment of the member pl_size of struct lp_msg. In particular, merging this would fix #65.