### PR TITLE
Count explicitly-failed tests in the failed test count

### DIFF
--- a/test/framework/self-tests/fail_assert1.c
+++ b/test/framework/self-tests/fail_assert1.c
@@ -1,5 +1,5 @@
 /**
- * @file test/self-tests/fail_assert.c
+ * @file test/self-tests/fail_assert1.c
  *
  * @brief Test: Test core functions of the testing framework
  *

--- a/test/framework/self-tests/fail_assert2.c
+++ b/test/framework/self-tests/fail_assert2.c
@@ -1,5 +1,5 @@
 /**
- * @file test/self-tests/fail_assert.c
+ * @file test/self-tests/fail_assert2.c
  *
  * @brief Test: Test core functions of the testing framework
  *

--- a/test/framework/test.c
+++ b/test/framework/test.c
@@ -42,7 +42,8 @@ void test_init(unsigned n_th)
 
 __attribute__((noreturn)) void fail(void)
 {
-	fprintf(stderr, "Failing explicitly\n");
+	printf("failed explicitly.\n");
+	test_unit.failed++;
 	longjmp(test_unit.fail_buffer, 1);
 }
 


### PR DESCRIPTION
If a test fails explicitly, this is counted in the failed tests and the test result message is printed to `stdout` rather than `stderr`.

This fixes #68.