### PR TITLE
Optionally build without MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ if(MSVC)
 endif()
 
 find_package(Threads REQUIRED)
-find_package(MPI REQUIRED)
+if(NOT DISABLE_MPI)
+    find_package(MPI REQUIRED)
+endif()
 
 add_compile_options(-Wall -Wextra -pedantic)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
-set(srcs
+set(rscore_srcs
         arch/io.c
         arch/mem.c
         arch/thread.c
@@ -9,7 +9,6 @@ set(srcs
         core/sync.c
         datatypes/msg_queue.c
         distributed/control_msg.c
-        distributed/mpi.c
         gvt/fossil.c
         gvt/gvt.c
         gvt/termination.c
@@ -30,10 +29,22 @@ set(srcs
         parallel/parallel.c
         serial/serial.c)
 
+if(NOT DISABLE_MPI)
+    set(rscore_srcs ${rscore_srcs} distributed/mpi.c)
+else()
+    set(rscore_srcs ${rscore_srcs} distributed/no_mpi.c)
+endif()
+
 # Build the core library
-add_library(rscore STATIC ${srcs})
+add_library(rscore STATIC ${rscore_srcs})
 
 target_compile_definitions(rscore PRIVATE ROOTSIM_VERSION="${PROJECT_VERSION}")
-target_include_directories(rscore PRIVATE . ${MPI_C_INCLUDE_PATH})
-target_compile_options(rscore PRIVATE ${MPI_C_COMPILE_FLAGS})
-target_link_libraries(rscore ${MPI_C_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_LIBS})
+target_include_directories(rscore PRIVATE .)
+target_link_libraries(rscore ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_LIBS})
+
+if(NOT DISABLE_MPI)
+    target_include_directories(rscore PRIVATE ${MPI_C_INCLUDE_PATH})
+    target_compile_options(rscore PRIVATE ${MPI_C_COMPILE_FLAGS})
+    target_link_libraries(rscore ${MPI_C_LIBRARIES})
+endif()
+

--- a/src/distributed/no_mpi.c
+++ b/src/distributed/no_mpi.c
@@ -16,6 +16,8 @@
 
 #include <distributed/mpi.h>
 
+#include <assert.h>
+
 void mpi_global_init(int *argc_p, char ***argv_p)
 {
 	(void)argc_p;
@@ -28,6 +30,7 @@ void mpi_remote_msg_send(struct lp_msg *msg, nid_t dest_nid)
 {
 	(void)msg;
 	(void)dest_nid;
+	assert(0);
 	__builtin_unreachable();
 }
 
@@ -35,6 +38,7 @@ void mpi_remote_anti_msg_send(struct lp_msg *msg, nid_t dest_nid)
 {
 	(void)msg;
 	(void)dest_nid;
+	assert(0);
 	__builtin_unreachable();
 }
 
@@ -45,6 +49,7 @@ void mpi_control_msg_broadcast(enum msg_ctrl_code ctrl)
 
 void mpi_control_msg_send_to(enum msg_ctrl_code ctrl, nid_t dest)
 {
+	assert(dest == 0);
 	if(dest)
 		__builtin_unreachable();
 

--- a/src/distributed/no_mpi.c
+++ b/src/distributed/no_mpi.c
@@ -1,0 +1,92 @@
+/**
+ * @file distributed/no_mpi.c
+ *
+ * @brief MPI Support Module
+ *
+ * This module implements all basic MPI facilities to let the distributed
+ * execution of a simulation model take place consistently.
+ *
+ * Several facilities are thread-safe, others are not. Check carefully which
+ * of these can be used by worker threads without coordination when relying
+ * on this module.
+ *
+ * SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+#include <distributed/mpi.h>
+
+void mpi_global_init(int *argc_p, char ***argv_p)
+{
+	(void)argc_p;
+	(void)argv_p;
+}
+
+void mpi_global_fini(void) {}
+
+void mpi_remote_msg_send(struct lp_msg *msg, nid_t dest_nid)
+{
+	(void)msg;
+	(void)dest_nid;
+	__builtin_unreachable();
+}
+
+void mpi_remote_anti_msg_send(struct lp_msg *msg, nid_t dest_nid)
+{
+	(void)msg;
+	(void)dest_nid;
+	__builtin_unreachable();
+}
+
+void mpi_control_msg_broadcast(enum msg_ctrl_code ctrl)
+{
+	control_msg_process(ctrl);
+}
+
+void mpi_control_msg_send_to(enum msg_ctrl_code ctrl, nid_t dest)
+{
+	if(dest)
+		__builtin_unreachable();
+
+	mpi_control_msg_broadcast(ctrl);
+}
+
+void mpi_remote_msg_handle(void) {}
+
+void mpi_remote_msg_drain(void) {}
+
+void mpi_reduce_sum_scatter(const uint32_t values[n_nodes], unsigned *result)
+{
+	*result = values[0];
+}
+
+bool mpi_reduce_sum_scatter_done(void)
+{
+	return true;
+}
+
+void mpi_reduce_min(double *node_min_p)
+{
+	(void)node_min_p;
+}
+
+bool mpi_reduce_min_done(void)
+{
+	return true;
+}
+
+void mpi_node_barrier(void) {}
+
+void mpi_blocking_data_send(const void *data, int data_size, nid_t dest)
+{
+	(void)data;
+	(void)data_size;
+	(void)dest;
+}
+
+void *mpi_blocking_data_rcv(int *data_size_p, nid_t src)
+{
+	(void)data_size_p;
+	(void)src;
+	return NULL;
+}


### PR DESCRIPTION
This PR renders possible to build and test ROOT-Sim core library without MPI: this behaviour can be enabled by passing -DDISABLE_MPI=1 on CMake's command line.