### PR TITLE
Print logo only on rank zero

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -142,7 +142,7 @@ int RootsimRun(void)
 	if(!global_config.serial)
 		mpi_global_init(NULL, NULL);
 
-	if(global_config.log_level < LOG_SILENT) {
+	if(global_config.log_level < LOG_SILENT && !rid) {
 		print_logo();
 		print_config();
 	}


### PR DESCRIPTION
If multiple MPI jobs are launched on a same machine, the configuration was printed multiple times at startup, which was unpleasant.