### PR TITLE
Install targets for the rscore library and ROOT-Sim.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,3 +48,5 @@ if(NOT DISABLE_MPI)
     target_link_libraries(rscore ${MPI_C_LIBRARIES})
 endif()
 
+install(FILES ROOT-Sim.h DESTINATION include)
+install(TARGETS rscore LIBRARY DESTINATION lib)


### PR DESCRIPTION
This PR adds CMake install targets for the rscore library and ROOT-Sim.h.
This is needed in order to make the integration with rootsimcc possible.