### PR TITLE
Causality check bugfix in the parallel ScheduleNewEvent()

### DIFF
--- a/src/lp/process.c
+++ b/src/lp/process.c
@@ -49,6 +49,7 @@ void ScheduleNewEvent(lp_id_t receiver, simtime_t timestamp, unsigned event_type
 	struct lp_msg *msg = msg_allocator_pack(receiver, timestamp, event_type, payload, payload_size);
 
 #ifndef NDEBUG
+	msg->raw_flags = 0;
 	if(msg_is_before(msg, current_msg)) {
 		logger(LOG_FATAL, "Scheduling a message in the past!");
 		abort();


### PR DESCRIPTION
With this PR we fix a small bug which can happen only in debug mode.
The parallel ScheduleNewEvent() now resets the message flags before checking the happens-before relation with the current message. This is necessary in case we are recycling an old anti-message buffer, which would result to have precedence over every other non anti-message same-timestamp message, such as the currently processed one.