### PR TITLE
Fixed the stats counts of anti-messages and rolled-back messages

### DIFF
--- a/src/lp/process.c
+++ b/src/lp/process.c
@@ -165,7 +165,6 @@ static inline void silent_execution(const struct lp_ctx *lp, array_count_t last_
 static inline void send_anti_messages(struct process_ctx *proc_p, array_count_t past_i)
 {
 	array_count_t p_cnt = array_count(proc_p->p_msgs);
-	stats_take(STATS_MSG_ANTI, p_cnt - past_i);
 	for(array_count_t i = past_i; i < p_cnt; ++i) {
 		struct lp_msg *msg = array_get_at(proc_p->p_msgs, i);
 
@@ -183,14 +182,14 @@ static inline void send_anti_messages(struct process_ctx *proc_p, array_count_t 
 					msg_queue_insert(msg);
 			}
 
+			stats_take(STATS_MSG_ANTI, 1);
 			msg = array_get_at(proc_p->p_msgs, ++i);
 		}
 
 		uint32_t f = atomic_fetch_add_explicit(&msg->flags, -MSG_FLAG_PROCESSED, memory_order_relaxed);
-		if(!(f & MSG_FLAG_ANTI)) {
+		if(!(f & MSG_FLAG_ANTI))
 			msg_queue_insert(msg);
-			stats_take(STATS_MSG_ROLLBACK, 1);
-		}
+		stats_take(STATS_MSG_ROLLBACK, 1);
 	}
 	array_count(proc_p->p_msgs) = past_i;
 }


### PR DESCRIPTION
The previous rolled-back message counter didn't take into account rolled-back messages which didn't need to be reprocessed, so they were being underestimated in count.

Also, the previous anti-message counter considered rolled-back messages as anti messages as well, so they where being overestimated in count.

This has been now fixed with the expected semantic of the two measures:
- rolled-back messages are processed messages whose effect on a LP has been rolled-back as part of a rollback operation
- anti-messages are sent messages that have been cancelled as part of a rollback operation