### PR TITLE
Update copyright year and scripts

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: CC0-1.0
 BasedOnStyle: LLVM
 Language: Cpp

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: CC0-1.0
 
 root = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: CC0-1.0
 
 # Prerequisites

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: CC0-1.0
 
 [FORMAT]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
 cmake_minimum_required(VERSION 3.12)
 project("ROOT-Sim core" LANGUAGES C DESCRIPTION "A General-Purpose Multi-threaded Parallel/Distributed Simulation Library")

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
 find_package(Doxygen OPTIONAL_COMPONENTS dot)
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
 import os
 import re

--- a/scripts/update_copyright.py
+++ b/scripts/update_copyright.py
@@ -11,9 +11,9 @@ root_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 for root, _, files in os.walk(root_path):
     for file_name in files:
         if not (file_name.endswith(".py") or file_name.endswith(".c") or
-            file_name.endswith(".cpp") or file_name.endswith(".h") or
-            file_name.endswith(".hpp") or file_name.endswith(".md") or
-            file_name.endswith(".txt") or file_name.startswith(".")):
+                file_name.endswith(".cpp") or file_name.endswith(".h") or
+                file_name.endswith(".hpp") or file_name.endswith(".md") or
+                file_name.endswith(".txt") or file_name.startswith(".")):
             continue
 
         file_path = os.path.join(root, file_name)

--- a/scripts/update_copyright.py
+++ b/scripts/update_copyright.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
+import datetime
 import os
 import re
-import datetime
 
 year = datetime.datetime.now().year
 root_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -13,7 +13,7 @@ for root, _, files in os.walk(root_path):
         if not (file_name.endswith(".py") or file_name.endswith(".c") or
             file_name.endswith(".cpp") or file_name.endswith(".h") or
             file_name.endswith(".hpp") or file_name.endswith(".md") or
-            file_name.endswith(".build")):
+            file_name.endswith(".txt") or file_name.startswith(".")):
             continue
 
         file_path = os.path.join(root, file_name)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
 set(rscore_srcs
         arch/io.c

--- a/src/ROOT-Sim.h
+++ b/src/ROOT-Sim.h
@@ -10,7 +10,7 @@
  * a simulation model. All function prototypes exposed to the application
  * developer are exposed and defined here.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/arch/io.c
+++ b/src/arch/io.c
@@ -6,7 +6,7 @@
  * This module defines architecture independent input-oputput facilities for the
  * use in the simulator
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <arch/io.h>

--- a/src/arch/io.h
+++ b/src/arch/io.h
@@ -6,7 +6,7 @@
  * This header declares architecture independent input-oputput facilities for
  * the use in the simulator
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/arch/mem.c
+++ b/src/arch/mem.c
@@ -6,7 +6,7 @@
  * This module implements some memory related utilities such as memory
  * statistics retrieval in a platform independent way
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <arch/mem.h>

--- a/src/arch/mem.h
+++ b/src/arch/mem.h
@@ -6,7 +6,7 @@
  * This header exposes some memory related utilities such as memory statistics
  * retrieval in a platform independent way
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/arch/platform.h
+++ b/src/arch/platform.h
@@ -8,7 +8,7 @@
  * In case of POSIX, it also tries to set some macros used to understand what
  * is the POSIX version on which we are running.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/arch/thread.c
+++ b/src/arch/thread.c
@@ -11,7 +11,7 @@
  * once all threads are synchronized on the barrier, the function returns
  * true to only one of them.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <arch/thread.h>

--- a/src/arch/thread.h
+++ b/src/arch/thread.h
@@ -11,7 +11,7 @@
  * once all threads are synchronized on the barrier, the function returns
  * true to only one of them.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/arch/timer.h
+++ b/src/arch/timer.h
@@ -5,7 +5,7 @@
  *
  * This header defines the timers which the simulator uses to monitor its internal behaviour
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -5,7 +5,7 @@
  *
  * Core ROOT-Sim functionalities
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <core/core.h>

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -5,7 +5,7 @@
  *
  * Core ROOT-Sim functionalities
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/core/intrinsics.h
+++ b/src/core/intrinsics.h
@@ -7,7 +7,7 @@
  * compiler optimizations which can be used to produce more efficient
  * code.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/core/sync.c
+++ b/src/core/sync.c
@@ -5,7 +5,7 @@
  *
  * This module defines synchronization primitives for the parallel runtime.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <core/sync.h>

--- a/src/core/sync.h
+++ b/src/core/sync.h
@@ -5,7 +5,7 @@
  *
  * This module defines synchronization primitives for the parallel runtime.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/datatypes/array.h
+++ b/src/datatypes/array.h
@@ -5,7 +5,7 @@
  *
  * Dynamic array datatype
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/datatypes/bitmap.h
+++ b/src/datatypes/bitmap.h
@@ -8,7 +8,7 @@
  * performances and simplicity reasons, doesn't remember its effective size;
  * consequently it doesn't check boundaries on the array that stores the bits.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/datatypes/heap.h
+++ b/src/datatypes/heap.h
@@ -5,7 +5,7 @@
  *
  * A very simple binary heap implemented on top of our dynamic array
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/datatypes/list.h
+++ b/src/datatypes/list.h
@@ -5,7 +5,7 @@
 *
 * A generic doubly-linked list
 *
-* SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+* SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 * SPDX-License-Identifier: GPL-3.0-only
 */
 #pragma once

--- a/src/datatypes/msg_queue.c
+++ b/src/datatypes/msg_queue.c
@@ -9,7 +9,7 @@
  * then cheap, while extractions simply empty the buffer into the private queue. This way the critically thread locked
  * code is minimal.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <datatypes/msg_queue.h>

--- a/src/datatypes/msg_queue.h
+++ b/src/datatypes/msg_queue.h
@@ -5,7 +5,7 @@
  *
  * Message queue datatype
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/distributed/control_msg.c
+++ b/src/distributed/control_msg.c
@@ -5,7 +5,7 @@
  *
  * The module in which remote control messages are wired to the other modules
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <distributed/control_msg.h>

--- a/src/distributed/control_msg.h
+++ b/src/distributed/control_msg.h
@@ -5,7 +5,7 @@
  *
  * The module in which remote control messages are wired to the other modules
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/distributed/mpi.c
+++ b/src/distributed/mpi.c
@@ -6,7 +6,7 @@
  * This module implements all basic MPI facilities to let the distributed execution of a simulation model take place
  * consistently.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <distributed/mpi.h>

--- a/src/distributed/mpi.h
+++ b/src/distributed/mpi.h
@@ -10,7 +10,7 @@
  * of these can be used by worker threads without coordination when relying
  * on this module.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/distributed/no_mpi.c
+++ b/src/distributed/no_mpi.c
@@ -10,7 +10,7 @@
  * of these can be used by worker threads without coordination when relying
  * on this module.
  *
- * SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 

--- a/src/gvt/fossil.c
+++ b/src/gvt/fossil.c
@@ -3,7 +3,7 @@
  *
  * @brief Housekeeping operations
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 

--- a/src/gvt/fossil.h
+++ b/src/gvt/fossil.h
@@ -6,7 +6,7 @@
  * In this module all the housekeeping operations related to GVT computation phase
  * are present.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/gvt/gvt.c
+++ b/src/gvt/gvt.c
@@ -10,7 +10,7 @@
  * in Proceedings of the 21st IEEE/ACM International Symposium on Distributed
  * Simulation and Real Time Applications, 2017, pp. 51–58
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <gvt/gvt.h>

--- a/src/gvt/gvt.h
+++ b/src/gvt/gvt.h
@@ -3,7 +3,7 @@
  *
  * @brief Global Virtual Time
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/gvt/termination.c
+++ b/src/gvt/termination.c
@@ -3,7 +3,7 @@
  *
  * @brief Termination detection module
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <gvt/termination.h>

--- a/src/gvt/termination.h
+++ b/src/gvt/termination.h
@@ -3,7 +3,7 @@
  *
  * @brief Termination detection module
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/init.c
+++ b/src/init.c
@@ -5,7 +5,7 @@
  *
  * This module implements the simulator initialization routines
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <arch/thread.h>

--- a/src/log/file.c
+++ b/src/log/file.c
@@ -5,7 +5,7 @@
 *
 * Some file utility functions
 *
-* SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+* SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 * SPDX-License-Identifier: GPL-3.0-only
  */
 

--- a/src/log/file.h
+++ b/src/log/file.h
@@ -5,7 +5,7 @@
 *
 * Some file utility functions
 *
-* SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+* SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 * SPDX-License-Identifier: GPL-3.0-only
 */
 #pragma once

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -5,7 +5,7 @@
  *
  * This library can be used to produce logs during simulation runs.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <stdarg.h>

--- a/src/log/log.h
+++ b/src/log/log.h
@@ -5,7 +5,7 @@
  *
  * This library can be used to produce logs during simulation runs.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/log/parse/rootsim_plot_multi.py
+++ b/src/log/parse/rootsim_plot_multi.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
 
 import sys
+
 import matplotlib.pyplot as plt
+
 from rootsim_stats import RSStats
 
 

--- a/src/log/parse/rootsim_plot_single.py
+++ b/src/log/parse/rootsim_plot_single.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
 
 import sys
+
 import matplotlib.pyplot as plt
+
 from rootsim_stats import RSStats
 
 

--- a/src/log/parse/rootsim_stats.py
+++ b/src/log/parse/rootsim_stats.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
 
 import copy

--- a/src/log/stats.c
+++ b/src/log/stats.c
@@ -5,7 +5,7 @@
  *
  * All facilities to collect, gather, and dump statistics are implemented in this module.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <log/stats.h>

--- a/src/log/stats.h
+++ b/src/log/stats.h
@@ -5,7 +5,7 @@
  *
  * All the facilities to collect, gather, and dump statistics are implemented in this module.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/lp/common.h
+++ b/src/lp/common.h
@@ -3,7 +3,7 @@
 *
 * @brief Common LP functionalities
 *
-* SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+* SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 * SPDX-License-Identifier: GPL-3.0-only
 */
 #pragma once

--- a/src/lp/lp.c
+++ b/src/lp/lp.c
@@ -5,7 +5,7 @@
  *
  * LP construction functions
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <lp/lp.h>

--- a/src/lp/lp.h
+++ b/src/lp/lp.h
@@ -5,7 +5,7 @@
  *
  * LP construction functions
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/lp/msg.h
+++ b/src/lp/msg.h
@@ -5,7 +5,7 @@
  *
  * Message management functions
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/lp/process.c
+++ b/src/lp/process.c
@@ -5,7 +5,7 @@
  *
  * This module contains the main logic for the parallel simulation runtime
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <lp/process.h>

--- a/src/lp/process.h
+++ b/src/lp/process.h
@@ -5,7 +5,7 @@
  *
  * LP state management functions
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/mm/auto_ckpt.c
+++ b/src/mm/auto_ckpt.c
@@ -5,7 +5,7 @@
  *
  * The module which attempts to select the best checkpoint interval
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <mm/auto_ckpt.h>

--- a/src/mm/auto_ckpt.h
+++ b/src/mm/auto_ckpt.h
@@ -5,7 +5,7 @@
  *
  * The module which attempts to select the best checkpoint interval
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/mm/buddy/buddy.c
+++ b/src/mm/buddy/buddy.c
@@ -3,7 +3,7 @@
  *
  * @brief A Buddy System implementation
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <mm/buddy/buddy.h>

--- a/src/mm/buddy/buddy.h
+++ b/src/mm/buddy/buddy.h
@@ -3,7 +3,7 @@
  *
  * @brief A Buddy System implementation
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/mm/buddy/ckpt.c
+++ b/src/mm/buddy/ckpt.c
@@ -3,7 +3,7 @@
  *
  * @brief Checkpointing capabilities
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <mm/buddy/ckpt.h>

--- a/src/mm/buddy/ckpt.h
+++ b/src/mm/buddy/ckpt.h
@@ -3,7 +3,7 @@
  *
  * @brief Checkpointing capabilities
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/mm/buddy/multi.c
+++ b/src/mm/buddy/multi.c
@@ -3,7 +3,7 @@
  *
  * @brief Handling of multiple buddy systems
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <mm/buddy/multi.h>

--- a/src/mm/buddy/multi.h
+++ b/src/mm/buddy/multi.h
@@ -3,7 +3,7 @@
  *
  * @brief Handling of multiple buddy systems
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/mm/mm.h
+++ b/src/mm/mm.h
@@ -5,7 +5,7 @@
  *
  * Memory Manager main header
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/mm/model_allocator.h
+++ b/src/mm/model_allocator.h
@@ -5,7 +5,7 @@
  *
  * Memory management functions for simulation models
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/mm/msg_allocator.c
+++ b/src/mm/msg_allocator.c
@@ -5,7 +5,7 @@
  *
  * Memory management functions for messages
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <mm/msg_allocator.h>

--- a/src/mm/msg_allocator.h
+++ b/src/mm/msg_allocator.h
@@ -5,7 +5,7 @@
  *
  * Memory management functions for messages
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/parallel/parallel.c
+++ b/src/parallel/parallel.c
@@ -3,7 +3,7 @@
  *
  * @brief Concurrent simulation engine
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <parallel/parallel.h>

--- a/src/parallel/parallel.h
+++ b/src/parallel/parallel.h
@@ -3,7 +3,7 @@
  *
  * @brief Concurrent simulation engine
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/src/serial/serial.c
+++ b/src/serial/serial.c
@@ -3,7 +3,7 @@
  *
  * @brief Sequential simulation engine
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <serial/serial.h>

--- a/src/serial/serial.h
+++ b/src/serial/serial.h
@@ -3,7 +3,7 @@
  *
  * @brief Sequential simulation engine
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2008-2021 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
 add_library(test_framework_lib STATIC
         framework/lp.c

--- a/test/framework/lp.c
+++ b/test/framework/lp.c
@@ -5,7 +5,7 @@
 *
 * This module allows to mock various parts of an LP for testing purposes
 *
-* SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+* SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 * SPDX-License-Identifier: GPL-3.0-only
 */
 #include <lp/lp.h>

--- a/test/framework/rng.c
+++ b/test/framework/rng.c
@@ -5,7 +5,7 @@
  *
  * An acceptable-quality pseudo random number generator to be used in tests
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <framework/rng.h>

--- a/test/framework/rng.h
+++ b/test/framework/rng.h
@@ -5,7 +5,7 @@
  *
  * An acceptable-quality pseudo random number generator to be used in tests
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <stdint.h>

--- a/test/framework/self-tests/fail_assert.c
+++ b/test/framework/self-tests/fail_assert.c
@@ -5,7 +5,7 @@
  *
  * This is the test that checks if explicit fail works.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/framework/self-tests/fail_explicit.c
+++ b/test/framework/self-tests/fail_explicit.c
@@ -5,7 +5,7 @@
  *
  * This is the test that checks if explicit fail works.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/framework/self-tests/fail_implicit.c
+++ b/test/framework/self-tests/fail_implicit.c
@@ -5,7 +5,7 @@
  *
  * This is the test that checks if explicit fail works.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/framework/self-tests/fail_implicit_multi.c
+++ b/test/framework/self-tests/fail_implicit_multi.c
@@ -5,7 +5,7 @@
  *
  * This is the test that checks if explicit fail works.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/framework/self-tests/fail_top_level_assert.c
+++ b/test/framework/self-tests/fail_top_level_assert.c
@@ -5,7 +5,7 @@
  *
  * This is the test that checks if explicit fail works.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 

--- a/test/framework/self-tests/main.c
+++ b/test/framework/self-tests/main.c
@@ -5,7 +5,7 @@
  *
  * Entry point for the test cases of the testing framework
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/framework/self-tests/stubs.c
+++ b/test/framework/self-tests/stubs.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: Test core functions of the testing framework
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/framework/self-tests/stubs.h
+++ b/test/framework/self-tests/stubs.h
@@ -3,7 +3,7 @@
 *
 * @brief Test: Test core functions of the testing framework
 *
-* SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+* SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 * SPDX-License-Identifier: GPL-3.0-only
 */
 #pragma once

--- a/test/framework/self-tests/unexp_pass_assert.c
+++ b/test/framework/self-tests/unexp_pass_assert.c
@@ -5,7 +5,7 @@
  *
  * This is the test that checks if assert can fail a test.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/framework/self-tests/unexp_pass_plain.c
+++ b/test/framework/self-tests/unexp_pass_plain.c
@@ -5,7 +5,7 @@
  *
  * This is the test that checks if assert can fail a test.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/framework/test.c
+++ b/test/framework/test.c
@@ -3,7 +3,7 @@
  *
  * @brief Custom minimalistic testing framework
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/framework/thread.c
+++ b/test/framework/thread.c
@@ -6,7 +6,7 @@
  * This module provides generic facilities for thread and core management. In particular, helper functions to startup
  * worker threads are exposed.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <framework/thread.h>

--- a/test/framework/thread.h
+++ b/test/framework/thread.h
@@ -6,7 +6,7 @@
  * This module provides generic facilities for thread and core management. In particular, helper functions to startup
  * worker threads are exposed.and a function to synchronize multiple threads on a software barrier.
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/test/test.h
+++ b/test/test.h
@@ -3,7 +3,7 @@
 *
 * @brief Custom minimalistic testing framework
 *
-* SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+* SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 * SPDX-License-Identifier: GPL-3.0-only
 */
 #pragma once

--- a/test/tests/core/load.c
+++ b/test/tests/core/load.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: initialization of the core library
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/tests/core/sync.c
+++ b/test/tests/core/sync.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: synchronization primitives test
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/tests/datatypes/bitmap.c
+++ b/test/tests/datatypes/bitmap.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: bitmap datatype
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <datatypes/bitmap.h>

--- a/test/tests/datatypes/msg_queue.c
+++ b/test/tests/datatypes/msg_queue.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: parallel message queue
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <memory.h>

--- a/test/tests/gvt/termination.c
+++ b/test/tests/gvt/termination.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: termination detection module
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/tests/integration/correctness/application.c
+++ b/test/tests/integration/correctness/application.c
@@ -3,7 +3,7 @@
  *
  * @brief Main module of the model used to verify the runtime correctness
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <tests/integration/correctness/application.h>

--- a/test/tests/integration/correctness/application.h
+++ b/test/tests/integration/correctness/application.h
@@ -3,7 +3,7 @@
  *
  * @brief Header of the model used to verify the runtime correctness
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #pragma once

--- a/test/tests/integration/correctness/functions.c
+++ b/test/tests/integration/correctness/functions.c
@@ -3,7 +3,7 @@
  *
  * @brief Helper functions of the model used to verify the runtime correctness
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <tests/integration/correctness/application.h>

--- a/test/tests/integration/correctness/output_256.c
+++ b/test/tests/integration/correctness/output_256.c
@@ -3,7 +3,7 @@
  *
  * @brief Correct output of the model used to verify correctness (with 256 LPs)
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <stdint.h>

--- a/test/tests/integration/correctness/parallel.c
+++ b/test/tests/integration/correctness/parallel.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: integration test of the serial runtime
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/tests/integration/correctness/serial.c
+++ b/test/tests/integration/correctness/serial.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: integration test of the serial runtime
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/tests/integration/phold.c
+++ b/test/tests/integration/phold.c
@@ -3,7 +3,7 @@
  *
  * @brief A simple and stripped phold implementation
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/tests/log/rootsim_stats_test.py
+++ b/test/tests/log/rootsim_stats_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+# SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
 # SPDX-License-Identifier: GPL-3.0-only
 import os
 import re

--- a/test/tests/log/stats.c
+++ b/test/tests/log/stats.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: statistics module test
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <log/stats.h>

--- a/test/tests/mm/buddy.c
+++ b/test/tests/mm/buddy.c
@@ -5,7 +5,7 @@
  *
  * A test of the buddy system allocator used to handle model's memory
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/tests/mm/buddy_hard.c
+++ b/test/tests/mm/buddy_hard.c
@@ -5,7 +5,7 @@
  *
  * A test of the buddy system allocator used to handle model's memory
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/tests/mm/main.c
+++ b/test/tests/mm/main.c
@@ -5,7 +5,7 @@
  *
  * Entry point for the test cases related to the memory allocator
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/tests/mm/parallel.c
+++ b/test/tests/mm/parallel.c
@@ -5,7 +5,7 @@
  *
  * Multiple stress tests of the model memory allocator. Based on t-test1 by Wolfram Glager
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <test.h>

--- a/test/tests/old_tests/gvt/gvt_test.c
+++ b/test/tests/old_tests/gvt/gvt_test.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: parallel gvt algorithm
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include "test.h"

--- a/test/tests/old_tests/lp/lp_test.c
+++ b/test/tests/old_tests/lp/lp_test.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: logical process lifetime handler module
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include "test.h"

--- a/test/tests/visibility/visibility_override.c
+++ b/test/tests/visibility/visibility_override.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: accessing a weak symbol that is overridden
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <string.h>

--- a/test/tests/visibility/visibility_weak.c
+++ b/test/tests/visibility/visibility_weak.c
@@ -3,7 +3,7 @@
  *
  * @brief Test: accessing a weak symbol that is not overridden
  *
- * SPDX-FileCopyrightText: 2008-2022 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <core/core.h>


### PR DESCRIPTION
The copyright notice was not updated for 2023.
Also, the `update_copyright.py` script was not aligned to the new structure of the project.

This should be moved to CI.