### PR TITLE
Fix visibility test and bump version script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.12)
 project("ROOT-Sim core" LANGUAGES C DESCRIPTION "A General-Purpose Multi-threaded Parallel/Distributed Simulation Library")
 
-set(PROJECT_VERSION 3.0.0-rc1)
+set(PROJECT_VERSION 3.0.0-rc.2)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -11,7 +11,6 @@ branch_name = check_output(['git', 'branch', '--show-current']).decode().strip()
 
 # Split version in major, minor, hotfix, and tag
 version = describe_str.split("-", 1)[0]
-version = version[1:]  # This is to remove the 'v' at the beginning of the previous tag name
 tag = "-" + describe_str.split("-", 1)[1].split("-", 1)[0]
 major, minor, hotfix = map(int, version.split(".", 3))
 

--- a/test/tests/visibility/visibility_weak.c
+++ b/test/tests/visibility/visibility_weak.c
@@ -12,5 +12,5 @@
 
 int main(void)
 {
-	return strcmp(core_version, "3.0.0-beta");
+	return strcmp(core_version, "3.0.0-rc.2");
 }


### PR DESCRIPTION
This commit fixes the following sequence of events, which caused an incident that was making the CI pipeline to fail in master:

- PR #93 was merged before bumping the version number.
- To make a proper release, 4a15b613622c2d4f987fb03139957267cdf04859 was committed directly to master in a rush to update the version number before inserting the version tag, but without using the bump version script (a manual change to CMakeLists.txt was made). This also resulted in a non-compliant version tag with what we coded.
- If we used bump_version.py in #93, we would have discovered that it was broken: in #59 we had a discussion on the tagging scheme, where we agreed on changing it. This was not reflected in bump_version.py.
- The weak visibility test became broken, making the CI pipeline fail

The last point went unnoticed due to the bad state of the Windows build, which is partially out of our control.

Lessons learnt:
- We should always check against the internal guidelines for flow management
- Never commit directly to master, even if the owners can
- The Windows pipeline failure may hide real issues.