### PR TITLE
Allow the core to detect the used compiler version

### DIFF
--- a/src/core/compiler.h
+++ b/src/core/compiler.h
@@ -1,0 +1,23 @@
+/**
+ * @file core/compiler.h
+ *
+ * @brief Compiler version detection variable
+ *
+ * Compiler version detection variable
+ *
+ * The variable rootsim_compiler_version is used to detect the compiler version.
+ * It is set to 0 by default, but it is overridden by the compiler when a model is compiled.
+ * The macro ROOTSIM_COMPILER_VERSION is used to check the compiler version.
+ *
+ * SPDX-FileCopyrightText: 2008-2023 HPDCS Group <rootsim@googlegroups.com>
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+#pragma once
+
+#include <stdint.h>
+
+/// The version of the compiler used to generate a model
+uint32_t __attribute__((weak)) rootsim_compiler_version = 0;
+
+/// This macro allows to convert a major, minor and patch version into a single uint32_t
+#define ROOTSIM_COMPILER_VERSION(a,b,c) (uint32_t)(((a) << 16) + ((b) << 8) + (c))

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 #include <core/core.h>
+#include <core/compiler.h>
 
 __thread rid_t rid;
 nid_t n_nodes = 1;


### PR DESCRIPTION
rootsim-cc will inject in the model a variable allowing the core to detect what version of the compiler was used to compile the code.