### PR TITLE
Fix a use-after-free in msg_queue_fini

### DIFF
--- a/src/datatypes/msg_queue.c
+++ b/src/datatypes/msg_queue.c
@@ -73,8 +73,9 @@ void msg_queue_fini(void)
 
 	struct lp_msg *m = atomic_load_explicit(&queues[rid].list, memory_order_relaxed);
 	while(m != NULL) {
+		struct lp_msg *next = m->next;
 		msg_allocator_free(m);
-		m = m->next;
+		m = next;
 	}
 }
 


### PR DESCRIPTION
If using large events buffers, messages are actually freed and not released to the message allocator.

In this case, the msg_queue_fini has a use-after-free that can cause a crash at simulation end, and prevents the statistics file to be generated.