### PR TITLE
Barrier fix

### DIFF
--- a/src/core/sync.c
+++ b/src/core/sync.c
@@ -26,15 +26,15 @@ bool sync_thread_barrier(void)
 	atomic_uint *c = cs + (phase & 1U);
 
 	if(phase & 2U) {
-		l = atomic_fetch_add_explicit(c, -1, memory_order_acq_rel) == 1;
+		l = atomic_fetch_add_explicit(c, -1, memory_order_release) == 1;
 		do {
-			r = atomic_load_explicit(c, memory_order_relaxed);
+			r = atomic_load_explicit(c, memory_order_acquire);
 		} while(r);
 	} else {
-		l = !atomic_fetch_add_explicit(c, 1, memory_order_acq_rel);
+		l = !atomic_fetch_add_explicit(c, 1, memory_order_release);
 		rid_t thr_cnt = global_config.n_threads;
 		do {
-			r = atomic_load_explicit(c, memory_order_relaxed);
+			r = atomic_load_explicit(c, memory_order_acquire);
 		} while(r != thr_cnt);
 	}
 


### PR DESCRIPTION
In the previous version of the barrier the compiler could, in theory, move some parts of the following critical section before the spin wait loop on the thread counter variable.

With the fix, this is not possible. We note though, that, on Linux, both gcc 13.3 and clang 18 produce identical test binaries.

Criticism and suggestions are always welcome!