### PR TITLE
Fix alignment error

### DIFF
--- a/src/mm/model_allocator.c
+++ b/src/mm/model_allocator.c
@@ -55,7 +55,7 @@ void model_allocator_lp_fini(const struct mm_state *self)
 
 	index = array_count(self->buddies);
 	while(index--)
-		mm_free(array_get_at(self->buddies, index));
+		mm_aligned_free(array_get_at(self->buddies, index));
 
 	array_fini(self->buddies);
 }
@@ -111,7 +111,9 @@ void *rs_malloc(size_t req_size)
 			return ret;
 	}
 
-	struct buddy_state *new_buddy = mm_alloc(sizeof(*new_buddy));
+	static_assert(sizeof(struct buddy_state) % alignof(struct buddy_state) == 0,
+	    "sizeof(struct buddy_state) must be a multiple of its alignment for aligned_alloc");
+	struct buddy_state *new_buddy = mm_aligned_alloc(alignof(struct buddy_state), sizeof(*new_buddy));
 	buddy_init(new_buddy);
 
 	for(index = 0; index < array_count(self->buddies); ++index)


### PR DESCRIPTION
This is a quick&dirty fix for an alignment error in the buddy system. Fixes #105.

Per the C standard, malloc() returns memory aligned to max_align_t, typically 8 bytes on some LP64 platforms (e.g., many Linux/ARM64 configurations) and 16 bytes on x86-64. The C standard does not guarantee
malloc() satisfies over-aligned types (with
alignment greater than max_align_t).

Possible problems in the previous implementation:
- Undefined behavior: Accessing a misaligned alignas(16) member is UB per C11 §6.2.8.
- SIMD crashes: If the compiler auto-vectorizes operations on longest[] or base_mem[] and emits SSE aligned loads/stores (movaps, ld1), a misaligned buffer will cause a hardware fault.
- Checkpoint corruption: The static_assert in buddy.h enforces contiguity between longest and base_mem. Misalignment of the struct could interact poorly with memcpy-based checkpoint/restore paths (checkpoint.c) if the compiler assumes alignment it doesn't actually have. I wasn't actually able to trigger this latter condition in any environment, but it should be nevertheless possible from my understanding.

On x86-64, malloc() typically returns 16-byte-aligned memory, so this bug is latent on the most common targets. It becomes active on platforms where max_align_t alignment is less than 16.
Since we pretend to be architecture-independent, I classify this as a severe bug.